### PR TITLE
fix: remediate penetration test findings (HIGH-01–HIGH-03, MED-01, MED-04, LOW-02)

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,7 +3,7 @@ declare global {
 	namespace App {
 		interface Locals {
 			user: {
-				id: string;
+				id: number;
 				email: string;
 			} | null;
 		}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import type { Handle } from '@sveltejs/kit';
 import { TokenManager } from '$lib/server/auth/token-manager';
+import { userApi } from '$lib/server/trenara';
 
 const tokenManager = TokenManager.getInstance();
 
@@ -19,17 +20,24 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 		return resolve(event);
 	}
 
-	// Set user data from cookies
-	const userId = event.cookies.get('user_id');
-	const userEmail = event.cookies.get('user_email');
-
-	if (userId && userEmail) {
-		event.locals.user = { id: userId, email: userEmail };
-	} else {
+	// Derive user identity from the access token via the Trenara API to prevent
+	// IDOR: reading user_id from a client-controllable cookie would allow an
+	// authenticated attacker to access another user's data by spoofing the cookie.
+	try {
+		const user = await userApi.getCurrentUser(event.cookies);
+		event.locals.user = { id: user.id, email: user.email };
+	} catch {
 		event.locals.user = null;
 	}
 
-	return resolve(event);
+	const response = await resolve(event);
+
+	response.headers.set(
+		'Content-Security-Policy',
+		"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://backend-prod.trenara.com; font-src 'self'; frame-ancestors 'none'"
+	);
+
+	return response;
 };
 
 export const handle = handleAuth;

--- a/src/lib/schemas/goal-history.ts
+++ b/src/lib/schemas/goal-history.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+const timeRegex = /^\d{2}:\d{2}:\d{2}$/;
+const paceRegex = /^\d{2}:\d{2}$/;
+
+export const archiveGoalSchema = z.object({
+	goal_name: z.string().min(1).max(255),
+	distance: z.string().min(1).max(50),
+	goal_time: z.string().regex(timeRegex, 'goal_time must be HH:MM:SS'),
+	goal_pace: z.string().regex(paceRegex, 'goal_pace must be MM:SS'),
+	final_predicted_time: z.string().regex(timeRegex).nullable().optional(),
+	final_predicted_pace: z.string().regex(paceRegex).nullable().optional(),
+	start_date: z.string().regex(dateRegex, 'start_date must be YYYY-MM-DD'),
+	end_date: z.string().regex(dateRegex, 'end_date must be YYYY-MM-DD')
+});
+
+export type ArchiveGoalData = z.infer<typeof archiveGoalSchema>;

--- a/src/lib/server/auth/token-manager.test.ts
+++ b/src/lib/server/auth/token-manager.test.ts
@@ -78,14 +78,14 @@ describe('setToken', () => {
 		expect(opts.maxAge).toBe(7200);
 	});
 
-	it('sets httpOnly only on the token cookie, not the expiration cookie', () => {
+	it('sets httpOnly on both the token cookie and the expiration cookie', () => {
 		const cookies = makeCookies();
 		const expiresAt = new Date(Date.now() + 3600 * 1000);
 
 		manager.setToken(cookies, 'tok', TokenType.AccessToken, expiresAt);
 
 		expect(cookies._store[TokenType.AccessToken].options.httpOnly).toBe(true);
-		expect(cookies._store[`${TokenType.AccessToken}_expiration`].options.httpOnly).toBeUndefined();
+		expect(cookies._store[`${TokenType.AccessToken}_expiration`].options.httpOnly).toBe(true);
 	});
 
 	it('sets secure:true in production (dev=false)', () => {

--- a/src/lib/server/auth/token-manager.ts
+++ b/src/lib/server/auth/token-manager.ts
@@ -29,7 +29,11 @@ export class TokenManager {
 		const nearFutureThreshold = 43200; // 12 hours in seconds
 		const now = Math.floor(Date.now() / 1000);
 
-		if (expirationDate - nearFutureThreshold < now && expirationDate > now) {
+		if (expirationDate <= now) {
+			return false;
+		}
+
+		if (expirationDate - nearFutureThreshold < now) {
 			return this.refreshToken(cookies);
 		}
 
@@ -87,6 +91,7 @@ export class TokenManager {
 			expires: expiresAt,
 			maxAge,
 			path: '/',
+			httpOnly: true,
 			secure: !dev,
 			sameSite: 'lax'
 		});

--- a/src/lib/server/trenara/auth.ts
+++ b/src/lib/server/trenara/auth.ts
@@ -27,7 +27,8 @@ export const authApi = {
 		return fetchClient.request<AuthResponse>('/oauth/token', {
 			method: 'POST',
 			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded'
+				'Content-Type': 'application/x-www-form-urlencoded',
+				Authorization: `Basic ${BASIC_BEARER_TOKEN}`
 			},
 			body: formData.toString()
 		});

--- a/src/routes/api/v1/goal-history/+server.ts
+++ b/src/routes/api/v1/goal-history/+server.ts
@@ -1,41 +1,41 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { TokenType } from '$lib/server/auth/types';
 import { goalHistoryDAO } from '$lib/server/db/goal-history';
+import { archiveGoalSchema } from '$lib/schemas/goal-history';
 
-export const GET: RequestHandler = async ({ cookies }) => {
-	if (!cookies.get(TokenType.AccessToken)) {
+export const GET: RequestHandler = async ({ locals }) => {
+	if (!locals.user) {
 		error(401, 'Unauthorized');
 	}
 
-	const userId = Number(cookies.get('user_id'));
-	if (!userId) {
-		error(401, 'User ID not found');
-	}
-
-	const records = await goalHistoryDAO.getGoalHistory(userId);
+	const records = await goalHistoryDAO.getGoalHistory(locals.user.id);
 	return json({ records });
 };
 
-export const POST: RequestHandler = async ({ request, cookies }) => {
-	if (!cookies.get(TokenType.AccessToken)) {
+export const POST: RequestHandler = async ({ request, locals }) => {
+	if (!locals.user) {
 		error(401, 'Unauthorized');
 	}
 
-	const userId = Number(cookies.get('user_id'));
-	if (!userId) {
-		error(401, 'User ID not found');
-	}
-
 	const body = await request.json();
+	const result = archiveGoalSchema.safeParse(body);
 
-	const { goal_name, distance, goal_time, goal_pace, final_predicted_time, final_predicted_pace, start_date, end_date } = body;
-
-	if (!goal_name || !distance || !goal_time || !goal_pace || !start_date || !end_date) {
-		error(400, 'Missing required fields');
+	if (!result.success) {
+		error(400, result.error.errors[0]?.message ?? 'Invalid request body');
 	}
 
-	const result = await goalHistoryDAO.archiveGoal(userId, {
+	const {
+		goal_name,
+		distance,
+		goal_time,
+		goal_pace,
+		final_predicted_time,
+		final_predicted_pace,
+		start_date,
+		end_date
+	} = result.data;
+
+	const record = await goalHistoryDAO.archiveGoal(locals.user.id, {
 		goal_name,
 		distance,
 		goal_time,
@@ -46,5 +46,5 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 		end_date
 	});
 
-	return json(result);
+	return json(record);
 };

--- a/src/routes/api/v1/prediction-history/+server.ts
+++ b/src/routes/api/v1/prediction-history/+server.ts
@@ -1,17 +1,11 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { TokenType } from '$lib/server/auth/types';
 import { predictionHistoryDAO } from '$lib/server/db/prediction-history';
-import { predictionHistoryQuerySchema, predictionRecordSchema } from '$lib/schemas/prediction';
+import { predictionRecordSchema } from '$lib/schemas/prediction';
 
-export const GET: RequestHandler = async ({ url, cookies }) => {
-	if (!cookies.get(TokenType.AccessToken)) {
+export const GET: RequestHandler = async ({ url, locals }) => {
+	if (!locals.user) {
 		error(401, 'Unauthorized');
-	}
-
-	const userId = Number(cookies.get('user_id'));
-	if (!userId) {
-		error(401, 'User ID not found');
 	}
 
 	const startDateParam = url.searchParams.get('startDate');
@@ -24,7 +18,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 		? Math.min(rawLimit, 200)
 		: undefined;
 
-	const records = await predictionHistoryDAO.getUserPredictionHistory(userId, {
+	const records = await predictionHistoryDAO.getUserPredictionHistory(locals.user.id, {
 		startDate,
 		limit
 	});
@@ -32,14 +26,9 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 	return json({ records });
 };
 
-export const POST: RequestHandler = async ({ request, cookies }) => {
-	if (!cookies.get(TokenType.AccessToken)) {
+export const POST: RequestHandler = async ({ request, locals }) => {
+	if (!locals.user) {
 		error(401, 'Unauthorized');
-	}
-
-	const userId = Number(cookies.get('user_id'));
-	if (!userId) {
-		error(401, 'User ID not found');
 	}
 
 	const body = await request.json();
@@ -50,6 +39,6 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 	}
 
 	const { time, pace } = result.data;
-	const storeResult = await predictionHistoryDAO.storeIfChanged(userId, time, pace);
+	const storeResult = await predictionHistoryDAO.storeIfChanged(locals.user.id, time, pace);
 	return json(storeResult);
 };


### PR DESCRIPTION
## Summary

Implements remediations for the security findings documented in `PENTEST_REPORT.md`.

- **HIGH-01 (IDOR):** `hooks.server.ts` now calls `userApi.getCurrentUser()` on every authenticated request to derive user identity from the Trenara API rather than a client-controllable cookie. All API endpoints use `event.locals.user.id` as the single authoritative user identity. *(Note: a follow-up PR will replace this with an HMAC-signed cookie to avoid the extra API call per request.)*
- **HIGH-02:** Added missing `Authorization: Basic ${BASIC_BEARER_TOKEN}` header to `refreshToken()`, matching the login flow.
- **HIGH-03:** `validateAndRefreshToken` now returns `false` immediately when the access token is already expired, instead of returning `true` and allowing expired tokens through.
- **MED-01:** Added `Content-Security-Policy` response header in `hooks.server.ts`.
- **MED-04:** New `archiveGoalSchema` (Zod) applied to the goal-history POST endpoint, replacing loose truthy checks with full type/format/length validation.
- **LOW-02:** Added `httpOnly: true` to token expiration cookies; updated the corresponding test.

## Test plan

- [ ] All 250 existing unit tests pass (`bun run test`)
- [ ] Type check passes (`bun run check`)
- [ ] Login, dashboard, goal history, and prediction history flows work end-to-end
- [ ] Verify expired access token is rejected at the app layer (not just by Trenara)
- [ ] Verify token refresh still works (confirm `Authorization: Basic` header is sent)
- [ ] Attempt to set a different `user_id` cookie and confirm goal/prediction data is not accessible

https://claude.ai/code/session_01Gpc3eZWYoQHmZ98u4RYBj3