### PR TITLE
hotfix: clear session on auth failure to prevent infinite redirect loop

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -27,6 +27,9 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 		const user = await userApi.getCurrentUser(event.cookies);
 		event.locals.user = { id: user.id, email: user.email };
 	} catch {
+		// If identity cannot be confirmed, clear all session cookies so the
+		// login page does not redirect back to the app and cause an infinite loop.
+		await tokenManager.logout(event.cookies);
 		event.locals.user = null;
 	}
 


### PR DESCRIPTION
## Problem

After merging PR #20, authenticated users experience an infinite loading spinner.

**Root cause:** When `userApi.getCurrentUser()` throws (Trenara API error, rate limit, network hiccup), `event.locals.user` is set to `null` but all session cookies remain intact. This creates a redirect loop:

1. Protected route (e.g. `/dashboard`) → `locals.user` is null → redirects to `/login`
2. Login page sees valid `access-token` cookie → redirects to `/dashboard`
3. Repeat forever → spinner never ends

## Fix

One-line change in `hooks.server.ts`: call `tokenManager.logout()` in the catch block to wipe all session cookies before setting `locals.user = null`. The login page then has no `access-token` cookie and shows the login form instead of looping.

## Test plan

- [ ] Merge and deploy
- [ ] Existing users will be logged out once and redirected to `/login` — this is expected
- [ ] After logging in again, the app loads normally

https://claude.ai/code/session_01Gpc3eZWYoQHmZ98u4RYBj3