### PR TITLE
fix: replace per-request API call with HMAC-signed user_id cookie (HIGH-01)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 BASIC_BEARER_TOKEN=your_trenara_basic_auth_token
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+SESSION_SECRET=a_random_32_plus_char_secret_string

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,3 +24,4 @@ jobs:
           BASIC_BEARER_TOKEN: placeholder
           SUPABASE_URL: https://placeholder.supabase.co
           SUPABASE_SERVICE_ROLE_KEY: placeholder
+          SESSION_SECRET: placeholder-secret-for-type-checking-only

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,6 @@
 import type { Handle } from '@sveltejs/kit';
 import { TokenManager } from '$lib/server/auth/token-manager';
-import { userApi } from '$lib/server/trenara';
+import { verifyUserId } from '$lib/server/auth/user-identity';
 
 const tokenManager = TokenManager.getInstance();
 
@@ -20,16 +20,17 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 		return resolve(event);
 	}
 
-	// Derive user identity from the access token via the Trenara API to prevent
-	// IDOR: reading user_id from a client-controllable cookie would allow an
-	// authenticated attacker to access another user's data by spoofing the cookie.
-	try {
-		const user = await userApi.getCurrentUser(event.cookies);
-		event.locals.user = { id: user.id, email: user.email };
-	} catch {
-		// If identity cannot be confirmed, clear all session cookies so the
-		// login page does not redirect back to the app and cause an infinite loop.
-		await tokenManager.logout(event.cookies);
+	// Verify user identity via HMAC signature stored at login.
+	// This prevents IDOR: an attacker who modifies the user_id cookie cannot
+	// produce a valid signature without the server-side SESSION_SECRET, so
+	// the tampered value is rejected here with no extra API call.
+	const userIdStr = event.cookies.get('user_id');
+	const userIdSig = event.cookies.get('user_id_sig');
+	const userEmail = event.cookies.get('user_email');
+
+	if (userIdStr && userIdSig && userEmail && verifyUserId(userIdStr, userIdSig)) {
+		event.locals.user = { id: Number(userIdStr), email: userEmail };
+	} else {
 		event.locals.user = null;
 	}
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -31,6 +31,10 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 	if (userIdStr && userIdSig && userEmail && verifyUserId(userIdStr, userIdSig)) {
 		event.locals.user = { id: Number(userIdStr), email: userEmail };
 	} else {
+		// Sig missing or invalid (e.g. existing session predates this change).
+		// Clear the entire session so the login page doesn't redirect back to
+		// the app, which would cause an infinite redirect loop.
+		await tokenManager.logout(event.cookies);
 		event.locals.user = null;
 	}
 

--- a/src/lib/server/auth/token-manager.ts
+++ b/src/lib/server/auth/token-manager.ts
@@ -150,6 +150,7 @@ export class TokenManager {
 		this.deleteToken(cookies, TokenType.AccessToken);
 		this.deleteToken(cookies, TokenType.RefreshToken);
 		cookies.delete('user_id', { path: '/' });
+		cookies.delete('user_id_sig', { path: '/' });
 		cookies.delete('user_email', { path: '/' });
 		cookies.delete('trenara_session', { path: '/' });
 	}

--- a/src/lib/server/auth/user-identity.ts
+++ b/src/lib/server/auth/user-identity.ts
@@ -1,0 +1,28 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import { SESSION_SECRET } from '$env/static/private';
+
+/**
+ * Sign a user ID with the server-side SESSION_SECRET.
+ * The signature is stored alongside the user_id cookie so that any
+ * client-side tampering with the user_id value is detectable without
+ * requiring an extra API call on every request.
+ */
+export function signUserId(userId: number): string {
+	return createHmac('sha256', SESSION_SECRET).update(String(userId)).digest('hex');
+}
+
+/**
+ * Verify that a user ID cookie value matches its stored signature.
+ * Uses a timing-safe comparison to prevent timing attacks.
+ */
+export function verifyUserId(userId: string, signature: string): boolean {
+	try {
+		const expected = createHmac('sha256', SESSION_SECRET).update(userId).digest('hex');
+		const expectedBuf = Buffer.from(expected, 'hex');
+		const actualBuf = Buffer.from(signature, 'hex');
+		if (expectedBuf.length !== actualBuf.length) return false;
+		return timingSafeEqual(expectedBuf, actualBuf);
+	} catch {
+		return false;
+	}
+}

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -4,6 +4,7 @@ import { loginSchema } from '$lib/schemas/auth';
 import { authApi } from '$lib/server/trenara/auth';
 import { userApi } from '$lib/server/trenara';
 import { TokenType } from '$lib/server/auth/types';
+import { signUserId } from '$lib/server/auth/user-identity';
 import { dev } from '$app/environment';
 
 export const load: PageServerLoad = async ({ cookies }) => {
@@ -59,10 +60,12 @@ export const actions: Actions = {
 				cookieOptions
 			);
 
-			// Fetch user profile to persist user_id and email as cookies,
-			// used by server-side API endpoints (e.g. prediction history).
+			// Fetch user profile to persist user_id and email as cookies.
+			// A server-signed signature is stored alongside user_id so that
+			// hooks.server.ts can verify identity without an extra API call.
 			const user = await userApi.getCurrentUser(cookies);
 			cookies.set('user_id', String(user.id), { ...cookieOptions, httpOnly: true });
+			cookies.set('user_id_sig', signUserId(user.id), { ...cookieOptions, httpOnly: true });
 			cookies.set('user_email', user.email, { ...cookieOptions, httpOnly: true });
 		} catch {
 			return fail(401, { message: 'Invalid email or password' });


### PR DESCRIPTION
## Summary

Replaces the HIGH-01 (IDOR) fix from PR #20 with a more efficient approach that avoids an extra Trenara API call on every authenticated request.

**Before (PR #20):** `hooks.server.ts` called `userApi.getCurrentUser()` on every request to derive user identity from the access token. Correct, but added a network round-trip to every page load.

**After (this PR):** At login, a server-side HMAC-SHA256 signature of the `user_id` is computed using `SESSION_SECRET` and stored as an additional `user_id_sig` httpOnly cookie. On every subsequent request, `hooks.server.ts` verifies the signature locally in microseconds — no API call needed. An attacker who tampers with the `user_id` cookie cannot forge a valid signature without `SESSION_SECRET`.

## Changes

- `src/lib/server/auth/user-identity.ts` — new module with `signUserId()` and `verifyUserId()` (timing-safe HMAC-SHA256)
- `src/routes/login/+page.server.ts` — stores `user_id_sig` cookie alongside `user_id` at login
- `src/lib/server/auth/token-manager.ts` — deletes `user_id_sig` on logout
- `src/hooks.server.ts` — verifies signature; clears entire session (prevents redirect loop) if sig is missing or invalid
- `.env.example` — documents the required `SESSION_SECRET` variable

## Prerequisites

- `SESSION_SECRET` must be set in Vercel environment variables (already done)

## Test plan

- [ ] All 250 tests pass
- [ ] Login sets `user_id`, `user_id_sig`, and `user_email` cookies (all httpOnly)
- [ ] Dashboard loads without extra `/api/me` call visible in network tab
- [ ] Tampering with `user_id` cookie value causes clean logout, not a redirect loop
- [ ] Logout clears `user_id_sig` along with other session cookies

https://claude.ai/code/session_01Gpc3eZWYoQHmZ98u4RYBj3