### PR TITLE
Add test execution to CI workflow on every push

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,3 +25,11 @@ jobs:
           SUPABASE_URL: https://placeholder.supabase.co
           SUPABASE_SERVICE_ROLE_KEY: placeholder
           SESSION_SECRET: placeholder-secret-for-type-checking-only
+
+      - name: Run tests
+        run: bun run test
+        env:
+          BASIC_BEARER_TOKEN: placeholder
+          SUPABASE_URL: https://placeholder.supabase.co
+          SUPABASE_SERVICE_ROLE_KEY: placeholder
+          SESSION_SECRET: placeholder-secret-for-type-checking-only


### PR DESCRIPTION
## Summary
- Adds a Vitest step to the existing `check.yml` GitHub Actions workflow
- All 250 tests now run on every push to GitHub, alongside the existing type-check and lint step
- Uses placeholder env vars (same as the check step) since the test setup mocks `$env/static/private`

## Test plan
- [x] Verified all 250 tests pass locally
- [ ] Confirm the CI workflow runs both check and test steps on this PR's push

🤖 Generated with [Claude Code](https://claude.com/claude-code)