### PR TITLE
Fix Supabase keep-alive: run every 3 days instead of 6

### DIFF
--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -2,11 +2,15 @@ name: Keep Supabase alive
 
 on:
   schedule:
-    - cron: '0 0 */6 * *' # every 6 days
+    - cron: '0 12 */3 * *' # every 3 days
+  workflow_dispatch:
 
 jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
       - name: Ping Supabase
-        run: curl -fsS -o /dev/null "${{ secrets.SUPABASE_URL }}/rest/v1/" -H "apikey:${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}"
+        run: |
+          echo "Pinging Supabase at $(date)"
+          curl -fsSv -o /dev/null "${{ secrets.SUPABASE_URL }}/rest/v1/" -H "apikey: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}"
+          echo "Ping successful"


### PR DESCRIPTION
The cron '*/6' in the day-of-month field runs on days 1,7,13,19,25.
In 31-day months the gap from day 25 to day 1 is exactly 7 days —
Supabase's inactivity limit — and GitHub Actions schedule delays can
push it past that, triggering a pause warning.

Also adds workflow_dispatch for manual runs and verbose curl output
to make debugging easier if the ping fails.

https://claude.ai/code/session_017122eq9BduodsxetsVF29b